### PR TITLE
Extern APIs for eigen_GPU_batch_BufferSize for third party tools and shared library generation

### DIFF
--- a/Makefile_cuda
+++ b/Makefile_cuda
@@ -62,16 +62,18 @@ LIBOPT = -leigenGbatch
 
 all: a.out $(LIBS)
 a.out : $(OBJSS) $(LIBS)
-	$(NVCC) -o $@ $(OBJSS) -L./ -L$(CUDA_PATH)/lib64 -lcuda -lcudart -lcusolver -lcublas -lm -lgomp
+	$(NVCC) -o $@ $(OBJSS) -L./ -L$(CUDA_PATH)/lib64 -L$(MATH_LIBS)/lib64/ -lcuda -lcudart -lcusolver -lcublas -lm -lgomp
 	cp a.out a.out-cuda
 
 main.o: main.cpp
-	$(NVCC) -c -o $@ $< -I$(CUDA_PATH)/include -DPRINT_DIAGNOSTIC=0 --compiler-options -fopenmp
+	$(NVCC) -c -o $@ $< -I$(CUDA_PATH)/include -I$(MATH_LIBS)/include/ -DPRINT_DIAGNOSTIC=0 --compiler-options -fopenmp
 libeigenGbatch.a: eigen_GPU_batch.o
-	ar cr libeigenGbatch.a $<
+	ar crs libeigenGbatch.a $<
 	ranlib libeigenGbatch.a 
+	nvcc -shared -o libeigenGbatchCUDA.so eigen_GPU_batch.o -lcudart
+
 eigen_GPU_batch.o: eigen_GPU_batch.cu
-	$(NVCC) -c -o $@ $(NVCCOPT) $<
+	$(NVCC) -c -o $@ -Xcompiler -fPIC $(NVCCOPT) $<
 	$(NVCC) --ptx $(NVCCOPTmin) $<
 eigen_GPU_check.o: eigen_GPU_check.cu
 	$(NVCC) -c -o $@ $(NVCCOPT) $<

--- a/Makefile_hip
+++ b/Makefile_hip
@@ -48,8 +48,9 @@ main.o: main.cpp
 libeigenGbatch.a: eigen_GPU_batch.o
 	ar cr libeigenGbatch.a $<
 	ranlib libeigenGbatch.a 
+	$(HIPCC) -shared -o libeigenGbatchHIP.so eigen_GPU_batch.o -lhipsolver -lm -lgomp
 eigen_GPU_batch.o: eigen_GPU_batch.cu
-	$(HIPCC) -c -o $@ $< $(HIPCCOPT)
+	$(HIPCC) -c -o $@ -fPIC $< $(HIPCCOPT)
 	$(HIPCC) -S $< $(HIPCCOPT)
 eigen_GPU_check.o: eigen_GPU_check.cu
 	$(HIPCC) -c -o $@ $< $(HIPCCOPT)

--- a/eigen_GPU_batch.cu
+++ b/eigen_GPU_batch.cu
@@ -326,6 +326,15 @@ eigen_GPU_batch_RUN(const int L, const int nm, const int n, const int m, T * a, 
 
 extern "C" {
 
+__host__ void eigen_GPU_batch_BufferSize_DP(const int L, const int nm, const int n, const int m, double * a, double * w, size_t *lwork)
+{
+    eigen_GPU_batch_BufferSize<double>(L, nm, n, m, a, w, lwork);
+}
+__host__ void eigen_GPU_batch_BufferSize_FP(const int L, const int nm, const int n, const int m, float * a, float * w, size_t *lwork)
+{
+    eigen_GPU_batch_BufferSize<float>(L, nm, n, m, a, w, lwork);
+}
+
 __host__ void
 eigen_GPU_batch_DP(const int L, const int nm, const int n, const int m, double * a, double * w, double *wk, const gpuStream_t stream)
 {

--- a/eigen_GPU_batch.h
+++ b/eigen_GPU_batch.h
@@ -29,6 +29,8 @@ eigen_GPU_batch_DP(const int L, const int nm, const int n, const int m, double *
 void
 eigen_GPU_batch_FP(const int L, const int nm, const int n, const int m, float * a, float * w, float *wk, const gpuStream_t stream);
 
+void eigen_GPU_batch_BufferSize_DP(const int L, const int nm, const int n, const int m, double * a, double * w, size_t *lwork);
+void eigen_GPU_batch_BufferSize_FP(const int L, const int nm, const int n, const int m, float * a, float * w, size_t *lwork);
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Added and exposed eigen_GPU_batch_BufferSize_DP and eigen_GPU_batch_BufferSize_FP APIs, which are required to compute the size of WK matrix; Makefile requirement to have Math library path, which is required according to NVHPC installation; Added shared library for both CUDA and HIP. 